### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ module: {
 module: {
   rules: [
     {
-      test: /\.stories\.tsx/,
+      test: /\.stories\.js/,
       use: [{ loader: “story-description-loader” }],
   ]
 }


### PR DESCRIPTION
should be `.js` instead of `.tsx`

Awesome plugin by the way, thank you for that!