### PR TITLE
Prevent overwrites of other config and update for Storybook 6

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,31 +17,6 @@ const babel = require("@babel/core")
 const validateOptions = require("schema-utils");
 const schema = require("./options.json")
 
-function createDescriptionNode(name, description) {
-    return babel.types.expressionStatement(
-        babel.types.assignmentExpression(
-            "=",
-            babel.types.memberExpression(babel.types.identifier(name), babel.types.identifier("story")),
-            babel.types.objectExpression([
-                babel.types.objectProperty(
-                    babel.types.identifier("parameters"),
-                    babel.types.objectExpression([
-                        babel.types.objectProperty(
-                            babel.types.identifier("docs"),
-                            babel.types.objectExpression([
-                                babel.types.objectProperty(
-                                    babel.types.identifier("storyDescription"),
-                                    babel.types.stringLiteral(description),
-                                ),
-                            ]),
-                        ),
-                    ]),
-                ),
-            ]),
-        ),
-    )
-}
-
 function annotateDescriptionPlugin() {
     return {
         visitor: {
@@ -63,8 +38,18 @@ function annotateDescriptionPlugin() {
                     })
                     const description = commentValues.join("\n")
                     const declaration = path.node.declaration.declarations[0]
+                    const storyId = declaration.id.name;
 
-                    path.insertAfter(createDescriptionNode(declaration.id.name, description))
+                    path.container.push(
+                      ...babel.template.ast`
+                        ${storyId}.parameters ??= {};
+                        ${storyId}.parameters.docs ??= {};
+                        ${storyId}.parameters.docs.description ??= {};
+                        ${storyId}.parameters.docs.description.story ??= ${JSON.stringify(
+                        description
+                      )};
+                        `
+                    );
                 }
             },
         },


### PR DESCRIPTION
Fixes #3 
Fixes #10

## Changes

This prevents the description loader from overwriting any existing story config in the code. This is achieved by two things:

- Only reassign the deeply-nested story description property itself, rather than the entire config object.
- Insert these statements at the very end of the story file, rather than right after the `export const MyStory = ...` declaration.

### Before

```jsx
/** My description. */
export const MyStory = () => {};
MyStory.parameters = { docs: { description: { story: 'My description.' } } }; // inserted by babel plugin
MyStory.parameters = { /* ... */ }; // written by consumer
```

### After

```jsx
/** My description. */
export const MyStory = () => {};
MyStory.parameters = { /* ... */ }; // written by consumer

// appended to the file by babel plugin
MyStory.parameters ??= {};
MyStory.parameters.docs ??= {};
MyStory.parameters.docs.description ??= {};
MyStory.parameters.docs.description.story ??= 'My description.';
```

As a result, any explicit config written by the consumer will not be overwritten by the babel plugin. Furthermore, any explicit story descriptions declared by the consumer via the `parameters` property will take precedence over the JSDoc comment.

---

In addition to this, the config path is updated for Storybook 6 (`MyStory.story.parameters.docs.storyDescription` → `MyStory.parameters.docs.description.story`, as described in the [migration](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#hoisted-csf-annotations) [docs](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#docs-description-parameter). Support for the deprecated path is slated to be removed in v7.) Let me know if you want to leave this part out of this PR, since I believe it will remove support for v5.